### PR TITLE
MoVM module.

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -39,7 +39,7 @@ lazy_static = "1.4"
 # like the DOM.
 [dependencies.web-sys]
 version = "0.3.22"
-features = ["console", "Window", "HtmlCanvasElement", "CanvasRenderingContext2d", "Document"]
+features = ["console", "Window", "HtmlCanvasElement", "CanvasRenderingContext2d", "Document", "Event", "KeyboardEvent", "MouseEvent"]
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -33,6 +33,7 @@ wee_alloc = { version = "0.4.2", optional = true }
 motoko = { path = "../../motoko.rs/crates/motoko" }
 # motoko = "0.0"
 motoko_proc_macro = "0.0"
+lazy_static = "1.4"
 
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.

--- a/template/src/document.rs
+++ b/template/src/document.rs
@@ -1,18 +1,14 @@
-use wasm_bindgen::prelude::*;
 use web_sys::Document;
 
-use motoko::vm_types::CoreSource;
-use motoko::{ast::Id, Interruption, Share, Value, Value_};
+use motoko::{ast::Id, Interruption, Value_};
 
 use std::hash::{Hash, Hasher};
-
-use crate::context::ContextValue;
 
 //#[macro_use]
 use motoko::{
     ast::Inst,
     dynamic::{Dynamic, Result},
-    type_mismatch,
+    //    type_mismatch,
     vm_types::Store,
 };
 
@@ -54,10 +50,10 @@ impl Dynamic for DocumentValue {
 }
 
 impl Dynamic for DocumentMethodValue {
-    fn call(&mut self, _store: &mut Store, _inst: &Option<Inst>, args: Value_) -> Result {
+    fn call(&mut self, _store: &mut Store, _inst: &Option<Inst>, _args: Value_) -> Result {
         match self.method {
             DocumentMethod::GetElementById => todo!(),
-            _ => type_mismatch!(file!(), line!()),
+            /* _ => type_mismatch!(file!(), line!()), */
         }
     }
 }

--- a/template/src/document.rs
+++ b/template/src/document.rs
@@ -1,0 +1,63 @@
+use wasm_bindgen::prelude::*;
+use web_sys::Document;
+
+use motoko::vm_types::CoreSource;
+use motoko::{ast::Id, Interruption, Share, Value, Value_};
+
+use std::hash::{Hash, Hasher};
+
+use crate::context::ContextValue;
+
+//#[macro_use]
+use motoko::{
+    ast::Inst,
+    dynamic::{Dynamic, Result},
+    type_mismatch,
+    vm_types::Store,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DocumentValue {
+    pub document: Document,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub enum DocumentMethod {
+    GetElementById,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DocumentMethodValue {
+    pub document: DocumentValue,
+    pub method: DocumentMethod,
+}
+
+impl Hash for DocumentValue {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        panic!("do not hash Document values, please");
+    }
+}
+
+impl Dynamic for DocumentValue {
+    fn get_field(&self, _store: &Store, name: &str) -> Result {
+        if name == "getElementById" {
+            Ok(DocumentMethodValue {
+                document: self.clone(),
+                method: DocumentMethod::GetElementById,
+            }
+            .into_value()
+            .into())
+        } else {
+            Err(Interruption::UnboundIdentifer(Id::new(name.to_string())))
+        }
+    }
+}
+
+impl Dynamic for DocumentMethodValue {
+    fn call(&mut self, _store: &mut Store, _inst: &Option<Inst>, args: Value_) -> Result {
+        match self.method {
+            DocumentMethod::GetElementById => todo!(),
+            _ => type_mismatch!(file!(), line!()),
+        }
+    }
+}

--- a/template/src/event.rs
+++ b/template/src/event.rs
@@ -1,0 +1,89 @@
+use wasm_bindgen::prelude::*;
+use web_sys::{console, Event, KeyboardEvent, MouseEvent, Window};
+
+use motoko::vm_types::CoreSource;
+use motoko::{ast::Id, Interruption, Share, Value, Value_};
+
+use std::hash::{Hash, Hasher};
+
+use crate::context::ContextValue;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct EventValue {
+    event: Event,
+}
+
+impl Hash for EventValue {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        panic!("do not hash Event values, please");
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MouseEventValue {
+    mouse_event: MouseEvent,
+}
+
+impl Hash for MouseEventValue {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        panic!("do not hash MouseEvent values, please");
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct KeyboardEventValue {
+    keyboard_event: KeyboardEvent,
+}
+
+impl Hash for KeyboardEventValue {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        panic!("do not hash KeyBoardEvent values, please");
+    }
+}
+
+//#[macro_use]
+use motoko::{
+    ast::Inst,
+    dynamic::{Dynamic, Result},
+    type_mismatch,
+    vm_types::Store,
+};
+
+impl Dynamic for EventValue {
+    fn get_field(&self, _store: &Store, name: &str) -> Result {
+        if name == "type" {
+            Ok(Value::Variant(Id::new(self.event.type_()), None).share())
+        } else {
+            type_mismatch!(file!(), line!())
+        }
+    }
+}
+
+impl Dynamic for MouseEventValue {
+    fn get_field(&self, _store: &Store, name: &str) -> Result {
+        if name == "type" {
+            Ok(Value::Variant(Id::new(self.mouse_event.type_()), None).share())
+
+        // to do -- clientX, clientY
+        } else {
+            type_mismatch!(file!(), line!())
+        }
+    }
+}
+
+impl Dynamic for KeyboardEventValue {
+    fn get_field(&self, _store: &Store, name: &str) -> Result {
+        if name == "type" {
+            Ok(Value::Variant(Id::new(self.keyboard_event.type_()), None).share())
+        } else if name == "key" {
+            Ok(Value::Text(motoko::value::Text::String(Box::new(
+                self.keyboard_event.key(),
+            )))
+            .share())
+
+        // to do -- all getter methods here -- https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.KeyboardEvent.html#implementations
+        } else {
+            type_mismatch!(file!(), line!())
+        }
+    }
+}

--- a/template/src/event.rs
+++ b/template/src/event.rs
@@ -1,16 +1,13 @@
-use wasm_bindgen::prelude::*;
-use web_sys::{console, Event, KeyboardEvent, MouseEvent, Window};
+use web_sys::{Event, KeyboardEvent, MouseEvent};
 
 use motoko::vm_types::CoreSource;
-use motoko::{ast::Id, Interruption, Share, Value, Value_};
+use motoko::{ast::Id, Interruption, Share, Value};
 
 use std::hash::{Hash, Hasher};
 
-use crate::context::ContextValue;
-
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct EventValue {
-    event: Event,
+pub struct EventValue {
+    pub event: Event,
 }
 
 impl Hash for EventValue {
@@ -20,8 +17,8 @@ impl Hash for EventValue {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct MouseEventValue {
-    mouse_event: MouseEvent,
+pub struct MouseEventValue {
+    pub mouse_event: MouseEvent,
 }
 
 impl Hash for MouseEventValue {
@@ -31,8 +28,8 @@ impl Hash for MouseEventValue {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct KeyboardEventValue {
-    keyboard_event: KeyboardEvent,
+pub struct KeyboardEventValue {
+    pub keyboard_event: KeyboardEvent,
 }
 
 impl Hash for KeyboardEventValue {
@@ -43,7 +40,6 @@ impl Hash for KeyboardEventValue {
 
 //#[macro_use]
 use motoko::{
-    ast::Inst,
     dynamic::{Dynamic, Result},
     type_mismatch,
     vm_types::Store,

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -5,7 +5,10 @@ use wasm_bindgen::prelude::*;
 mod canvas;
 mod console;
 mod context;
+mod document;
 mod event;
+mod window;
+
 mod movm;
 
 //#[macro_use]
@@ -39,6 +42,12 @@ pub fn main_js() -> Result<(), JsValue> {
 #[wasm_bindgen]
 pub fn draw_on_canvas(canvas_id: &str) -> Result<(), JsValue> {
     let window = web_sys::window().unwrap();
+
+    let window_value = window::WindowValue {
+        window: window.clone(),
+    }
+    .into_value()
+    .share();
 
     let document = window.document().expect("should have a document on window");
 
@@ -75,6 +84,7 @@ pub fn draw_on_canvas(canvas_id: &str) -> Result<(), JsValue> {
                     console::ConsoleLogValue {}.into_value().share(),
                 ),
                 ("canvas", canvas_value),
+                ("window", window_value),
             ],
             program,
         )

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -51,6 +51,12 @@ pub fn draw_on_canvas(canvas_id: &str) -> Result<(), JsValue> {
 
     let document = window.document().expect("should have a document on window");
 
+    let document_value: Value_ = document::DocumentValue {
+        document: document.clone(),
+    }
+    .into_value()
+    .share();
+
     let canvas = document
         .get_element_by_id(canvas_id)
         .unwrap()
@@ -74,16 +80,17 @@ pub fn draw_on_canvas(canvas_id: &str) -> Result<(), JsValue> {
     // c.arc(137.0, 137.0, 42.666, 0.0, 3.0 * std::f64::consts::PI);
     // c.stroke();
     //
-    let program = parse_static!("consoleLog(\"hello from Motoko\"); let c = canvas.getContext(\"2d\"); consoleLog(\"hello from Motoko 2\"); consoleLog(\"hello from Motoko 3\"); c.beginPath(); consoleLog(\"hello from Motoko 4\"); c.arc(137.0, 137.0, 42.666, 0.0, 9.42); c.stroke(); consoleLog(\"hello from Motoko 5\"); var x = 666;").clone();
+    let program = parse_static!("window.addEventListener(\"keydown\", func(e){ consoleLog(\"Motoko key press\"); }); consoleLog(\"hello from Motoko\"); let c = canvas.getContext(\"2d\"); consoleLog(\"hello from Motoko 2\"); consoleLog(\"hello from Motoko 3\"); c.beginPath(); consoleLog(\"hello from Motoko 4\"); c.arc(137.0, 137.0, 42.666, 0.0, 9.42); c.stroke(); consoleLog(\"hello from Motoko 5\"); var x = 666;").clone();
 
     movm::update(|core| {
         core.eval_open_block(
             vec![
+                ("canvas", canvas_value),
                 (
                     "consoleLog",
                     console::ConsoleLogValue {}.into_value().share(),
                 ),
-                ("canvas", canvas_value),
+                ("document", document_value),
                 ("window", window_value),
             ],
             program,

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 mod canvas;
 mod console;
 mod context;
+mod event;
 mod movm;
 
 //#[macro_use]
@@ -64,7 +65,7 @@ pub fn draw_on_canvas(canvas_id: &str) -> Result<(), JsValue> {
     // c.arc(137.0, 137.0, 42.666, 0.0, 3.0 * std::f64::consts::PI);
     // c.stroke();
     //
-    let program = parse_static!("consoleLog(\"hello from Motoko\"); let c = canvas.getContext(\"2d\"); consoleLog(\"hello from Motoko 2\"); consoleLog(\"hello from Motoko 3\"); c.beginPath(); consoleLog(\"hello from Motoko 4\"); c.arc(137.0, 137.0, 42.666, 0.0, 9.42); c.stroke(); consoleLog(\"hello from Motoko 5\"); ").clone();
+    let program = parse_static!("consoleLog(\"hello from Motoko\"); let c = canvas.getContext(\"2d\"); consoleLog(\"hello from Motoko 2\"); consoleLog(\"hello from Motoko 3\"); c.beginPath(); consoleLog(\"hello from Motoko 4\"); c.arc(137.0, 137.0, 42.666, 0.0, 9.42); c.stroke(); consoleLog(\"hello from Motoko 5\"); var x = 666;").clone();
 
     movm::update(|core| {
         core.eval_open_block(

--- a/template/src/lib.rs
+++ b/template/src/lib.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::prelude::*;
 mod canvas;
 mod console;
 mod context;
+mod movm;
 
 //#[macro_use]
 use motoko::{

--- a/template/src/movm.rs
+++ b/template/src/movm.rs
@@ -1,5 +1,5 @@
 use motoko::{
-    ast::{Exp, Exp_, NodeData},
+    ast::{Exp, NodeData},
     value::Value_,
     vm_types::{Core, Result},
     Share,
@@ -29,10 +29,15 @@ where
     r.unwrap()
 }
 
-pub fn call(f: Exp_, v: Value_) -> Result {
+pub fn call(f: Value_, v: Value_) -> Result {
     update(|core| {
         core.eval_exp(
-            NodeData::eval(Exp::Call(f, None, NodeData::eval(Exp::Value_(v)).share())).share(),
+            NodeData::eval(Exp::Call(
+                NodeData::eval(Exp::Value_(f)).share(),
+                None,
+                NodeData::eval(Exp::Value_(v)).share(),
+            ))
+            .share(),
         )
     })
 }

--- a/template/src/movm.rs
+++ b/template/src/movm.rs
@@ -1,0 +1,23 @@
+use motoko::vm_types::Core;
+use std::cell::RefCell;
+
+// Define a global mutable cell for the_core using RefCell and Rc
+thread_local! {
+    static THE_CORE: RefCell<Core> = RefCell::new(Core::empty());
+}
+
+// Accessor to get the value of the_core (read-only)
+pub fn get() -> Core {
+    THE_CORE.with(|c| c.borrow().clone())
+}
+
+// Accessor to read and update the value of the_core (mutably)
+pub fn update<F>(update_fn: F)
+where
+    F: FnOnce(&mut Core),
+{
+    THE_CORE.with(|c| {
+        let mut core = c.borrow_mut();
+        update_fn(&mut core);
+    });
+}

--- a/template/src/window.rs
+++ b/template/src/window.rs
@@ -1,0 +1,78 @@
+use wasm_bindgen::prelude::*;
+use web_sys::Window;
+
+use motoko::vm_types::CoreSource;
+use motoko::{ast::Id, Interruption, Share, Value, Value_};
+
+use std::hash::{Hash, Hasher};
+
+use crate::context::ContextValue;
+
+//#[macro_use]
+use motoko::{
+    ast::Inst,
+    dynamic::{Dynamic, Result},
+    type_mismatch,
+    vm_types::Store,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WindowValue {
+    pub window: Window,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub enum WindowMethod {
+    AddEventListener,
+    Document,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct WindowMethodValue {
+    pub window: WindowValue,
+    pub method: WindowMethod,
+}
+
+impl Hash for WindowValue {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        panic!("do not hash Window values, please");
+    }
+}
+
+impl Dynamic for WindowValue {
+    fn get_field(&self, _store: &Store, name: &str) -> Result {
+        if name == "document" {
+            match self.window.document() {
+                None => Ok(Value::Null.share()),
+                Some(document) => Ok(Value::Option(
+                    crate::document::DocumentValue { document }
+                        .into_value()
+                        .share(),
+                )
+                .share()),
+            }
+        } else if name == "addEventListener" {
+            Ok(WindowMethodValue {
+                window: self.clone(),
+                method: WindowMethod::AddEventListener,
+            }
+            .into_value()
+            .into())
+        } else {
+            Err(Interruption::UnboundIdentifer(Id::new(name.to_string())))
+        }
+    }
+}
+
+impl Dynamic for WindowMethodValue {
+    fn call(&mut self, _store: &mut Store, _inst: &Option<Inst>, args: Value_) -> Result {
+        match self.method {
+            WindowMethod::AddEventListener => {
+                // to do -- look at arg to case analyze the event type.
+                // handle each of: {key{Down, Up, Press}, mouse{Down, Up, Press}}
+                todo!()
+            }
+            _ => type_mismatch!(file!(), line!()),
+        }
+    }
+}


### PR DESCRIPTION
- MoVM has a global cell for `THE_CORE`, for handling callbacks.
- Callbacks installed into the `web_sys` crate's functionality can use this global cell to run Motoko code and effect both the web_sys state and the state of `THE_CORE`.

This Motoko snippet works now:
```
window.addEventListener("keydown", func(e){ consoleLog("Motoko key press"); }
```